### PR TITLE
powerpc: update mem barrier instructions

### DIFF
--- a/ocoms/sys/powerpc/atomic.h
+++ b/ocoms/sys/powerpc/atomic.h
@@ -31,6 +31,7 @@
 #define MB()  __asm__ __volatile__ ("sync" : : : "memory")
 #define RMB() __asm__ __volatile__ ("lwsync" : : : "memory")
 #define WMB() __asm__ __volatile__ ("eieio" : : : "memory")
+#define ISYNC __asm__ __volatile__ ("isync" : : : "memory")
 #define SMP_SYNC  "sync \n\t"
 #define SMP_ISYNC "\n\tisync"
 
@@ -88,7 +89,7 @@ void ocoms_atomic_rmb(void)
 static inline
 void ocoms_atomic_wmb(void)
 {
-    WMB();
+    RMB();
 }
 
 #elif OCOMS_XLC_INLINE_ASSEMBLY /* end OCOMS_GCC_INLINE_ASSEMBLY */


### PR DESCRIPTION
- added isync
- define ocoms_atomic_wmb() to lwsync as it is recommend over eieio
   on cache enabled storage.
  (http://www.ibm.com/developerworks/systems/articles/powerpc.html).
