### PR TITLE
Hcoll libocoms update

### DIFF
--- a/ocoms/datatype/ocoms_datatype.h
+++ b/ocoms/datatype/ocoms_datatype.h
@@ -226,6 +226,7 @@ ocoms_datatype_is_contiguous_memory_layout( const ocoms_datatype_t* datatype, in
 
 
 OCOMS_DECLSPEC void ocoms_datatype_dump( const ocoms_datatype_t* pData );
+OCOMS_DECLSPEC void ocoms_datatype_dump_v2( const ocoms_datatype_t* pData, bool dump_to_stderr );
 /* data creation functions */
 OCOMS_DECLSPEC int32_t ocoms_datatype_clone( const ocoms_datatype_t * src_type, ocoms_datatype_t * dest_type );
 OCOMS_DECLSPEC int32_t ocoms_datatype_create_contiguous( int count, const ocoms_datatype_t* oldType, ocoms_datatype_t** newType );

--- a/ocoms/datatype/ocoms_datatype_dump.c
+++ b/ocoms/datatype/ocoms_datatype_dump.c
@@ -102,7 +102,7 @@ int ocoms_datatype_dump_data_desc( dt_elem_desc_t* pDesc, int nbElems, char* ptr
 }
 
 
-void ocoms_datatype_dump( const ocoms_datatype_t* pData )
+void ocoms_datatype_dump_v2( const ocoms_datatype_t* pData, bool dump_to_stderr)
 {
     size_t length;
     int index = 0;
@@ -144,7 +144,15 @@ void ocoms_datatype_dump( const ocoms_datatype_t* pData )
         index += snprintf( buffer + index, length - index, "No optimized description\n" );
     }
     buffer[index] = '\0';  /* make sure we end the string with 0 */
-    DUMP("%s\n", buffer );
+    if (dump_to_stderr) {
+        fprintf(stderr, "%s\n", buffer);
+    } else {
+        DUMP("%s\n", buffer );
+    }
 
     free(buffer);
+}
+
+void ocoms_datatype_dump( const ocoms_datatype_t* pData) {
+    return ocoms_datatype_dump_v2(pData, false);
 }

--- a/ocoms/util/ocoms_free_list.c
+++ b/ocoms/util/ocoms_free_list.c
@@ -63,7 +63,7 @@ static void ocoms_free_list_destruct(ocoms_free_list_t* fl)
 {
     ocoms_list_item_t *item;
     ocoms_free_list_memory_t *fl_mem;
-
+    ocoms_free_list_item_t *fl_item;
 #if 0 && OCOMS_ENABLE_DEBUG
     if(ocoms_list_get_size(&fl->super) != fl->fl_num_allocated) {
         ocoms_output(0, "ocoms_free_list: %d allocated %d returned: %s:%d\n",
@@ -71,6 +71,14 @@ static void ocoms_free_list_destruct(ocoms_free_list_t* fl)
             fl->super.super.cls_init_file_name, fl->super.super.cls_init_lineno);
     }
 #endif
+    while(NULL != (item = ocoms_atomic_lifo_pop(&(fl->super)))) {
+        fl_item = (ocoms_free_list_item_t*)item;
+
+        /* destruct the item (we constructed it), the underlying memory will be
+         * reclaimed when we free the slab (opal_free_list_memory_t ptr)
+         * containing it */
+        OBJ_DESTRUCT(fl_item);
+    }
 
     if( NULL != fl->free ) {
         while(NULL != (item = ocoms_list_remove_first(&(fl->fl_allocations)))) {


### PR DESCRIPTION
2 updates:
1. Fixes the free_list_destruct (an element destructor was not called before causing a mem leak).
2. Adds convenience datatype_dump api used by hcoll.