### PR TITLE
not use _STRINGIFY on something that's not a numerical constant

### DIFF
--- a/config/ocoms_check_compiler_version.m4
+++ b/config/ocoms_check_compiler_version.m4
@@ -23,7 +23,7 @@ AC_DEFUN([OCOMS_CHECK_COMPILER_VERSION_ID],
     OCOMS_CHECK_COMPILER(FAMILYID)
     OCOMS_CHECK_COMPILER_STRINGIFY(FAMILYNAME)
     OCOMS_CHECK_COMPILER(VERSION)
-    OCOMS_CHECK_COMPILER_STRINGIFY(VERSION_STR)
+    OCOMS_CHECK_COMPILER_STRING(VERSION_STR)
 ])dnl
 
 
@@ -51,7 +51,40 @@ int main (int argc, char * argv[])
             ], [
                 eval ocoms_cv_compiler_$1=0
             ], [
+
                 eval ocoms_cv_compiler_$1=0
+            ])
+            CPPFLAGS=$CPPFLAGS_orig
+    ])
+    AC_DEFINE_UNQUOTED([OCOMS_BUILD_PLATFORM_COMPILER_$1], $ocoms_cv_compiler_[$1],
+                       [The compiler $lower which OMPI was built with])
+])dnl
+
+AC_DEFUN([OCOMS_CHECK_COMPILER_STRING], [
+    lower=m4_tolower($1)
+    AC_CACHE_CHECK([for compiler $lower], ocoms_cv_compiler_[$1],
+    [
+            CPPFLAGS_orig=$CPPFLAGS
+            CPPFLAGS="-I${OCOMS_TOP_SRCDIR}/ocoms/include/ocoms $CPPFLAGS"
+            AC_TRY_RUN([
+#include <stdio.h>
+#include <stdlib.h>
+#include "ocoms_portable_platform.h"
+
+int main (int argc, char * argv[])
+{
+    FILE * f;
+    f=fopen("conftestval", "w");
+    if (!f) exit(1);
+    fprintf (f, "%s", PLATFORM_COMPILER_$1);
+    return 0;
+}
+            ], [
+                eval ocoms_cv_compiler_$1=`cat conftestval`;
+            ], [
+                eval ocoms_cv_compiler_$1=UNKNOWN
+            ], [
+                eval ocoms_cv_compiler_$1=UNKNOWN
             ])
             CPPFLAGS=$CPPFLAGS_orig
     ])


### PR DESCRIPTION
porting https://github.com/open-mpi/ompi/commit/9780043456e19727f37ba8f926e0f50f783a3bbf