### PR TITLE
Change ocoms mca prefix

### DIFF
--- a/ocoms/mca/base/base.h
+++ b/ocoms/mca/base/base.h
@@ -228,6 +228,7 @@ OCOMS_DECLSPEC int ocoms_mca_base_components_close(int output_id, ocoms_list_t *
 OCOMS_DECLSPEC int ocoms_mca_base_framework_components_close (struct ocoms_mca_base_framework_t *framework,
 						       const ocoms_mca_base_component_t *skip);
 
+OCOMS_DECLSPEC void ocoms_mca_base_set_component_template(char *template);
 END_C_DECLS
 
 #endif /* MCA_BASE_H */

--- a/ocoms/mca/base/mca_base_framework.h
+++ b/ocoms/mca/base/mca_base_framework.h
@@ -175,8 +175,8 @@ OCOMS_DECLSPEC int ocoms_mca_base_framework_register (ocoms_mca_base_framework_t
  *
  * Call a framework's open function.
  */
-OCOMS_DECLSPEC int ocoms_ca_base_framework_open (ocoms_mca_base_framework_t *framework,
-                                           ocoms_mca_base_open_flag_t flags);
+OCOMS_DECLSPEC int ocoms_mca_base_framework_open (ocoms_mca_base_framework_t *framework,
+                                                  ocoms_mca_base_open_flag_t flags);
 
 /**
  * Close a framework


### PR DESCRIPTION
Allow changing the component name prefix: e.g., "hmca" instead of "mca" for better flexibility. The prefix name string was hardcoded to be "mca". Hence an ocoms user was forced to call its components (as well as component structures) following this hardcoded template, i.e. mca_<runtime_mca_name>_<runtime_component_name>.so.

With the new api it can be any prefix. 