### PR TITLE
Resolve name confilict with ompi/opal mca_cuda_convertor_init

### DIFF
--- a/ocoms/datatype/ocoms_convertor.c
+++ b/ocoms/datatype/ocoms_convertor.c
@@ -556,7 +556,7 @@ int32_t ocoms_convertor_prepare_for_recv( ocoms_convertor_t* convertor,
 
     convertor->flags |= CONVERTOR_RECV;
 #if OCOMS_CUDA_SUPPORT
-    mca_cuda_convertor_init(convertor, pUserBuf);
+    ocoms_cuda_convertor_init(convertor, pUserBuf);
 #endif
 
     OCOMS_CONVERTOR_PREPARE( convertor, datatype, count, pUserBuf );
@@ -595,7 +595,7 @@ int32_t ocoms_convertor_prepare_for_send( ocoms_convertor_t* convertor,
 {
     convertor->flags |= CONVERTOR_SEND;
 #if OCOMS_CUDA_SUPPORT
-    mca_cuda_convertor_init(convertor, pUserBuf);
+    ocoms_cuda_convertor_init(convertor, pUserBuf);
 #endif
 
     OCOMS_CONVERTOR_PREPARE( convertor, datatype, count, pUserBuf );

--- a/ocoms/datatype/ocoms_datatype_cuda.c
+++ b/ocoms/datatype/ocoms_datatype_cuda.c
@@ -42,7 +42,7 @@ void ocoms_cuda_add_initialization_function(int (*fptr)(ocoms_common_cuda_functi
  * is enabled or not.  If CUDA is not enabled, then short circuit out
  * for all future calls.
  */
-void mca_cuda_convertor_init(ocoms_convertor_t* convertor, const void *pUserBuf)
+void ocoms_cuda_convertor_init(ocoms_convertor_t* convertor, const void *pUserBuf)
 {   
     /* Only do the initialization on the first GPU access */
     if (!initialized) {

--- a/ocoms/datatype/ocoms_datatype_cuda.h
+++ b/ocoms/datatype/ocoms_datatype_cuda.h
@@ -23,7 +23,7 @@ struct ocoms_common_cuda_function_table {
 };
 typedef struct ocoms_common_cuda_function_table ocoms_common_cuda_function_table_t;
 
-void mca_cuda_convertor_init(ocoms_convertor_t* convertor, const void *pUserBuf);
+void ocoms_cuda_convertor_init(ocoms_convertor_t* convertor, const void *pUserBuf);
 bool ocoms_cuda_check_bufs(char *dest, char *src);
 void* ocoms_cuda_memcpy(void * dest, const void * src, size_t size, ocoms_convertor_t* convertor);
 void* ocoms_cuda_memcpy_sync(void * dest, void * src, size_t size);


### PR DESCRIPTION
    Name conflict would result in a memory corruption when ompi/opal
    mca_cuda_convertor_init is called insted of the proper ocoms
    function (corrupting the ocoms_convertor_t data struct)