### PR TITLE
Option to skip component_find_check during framework_open

### DIFF
--- a/ocoms/mca/base/base.h
+++ b/ocoms/mca/base/base.h
@@ -149,10 +149,10 @@ OCOMS_DECLSPEC char * ocoms_mca_base_component_to_string(const ocoms_mca_base_co
 /* ocoms_mca_base_component_find.c */
 
 OCOMS_DECLSPEC int ocoms_mca_base_component_find(const char *directory, const char *type,
-                                          const ocoms_mca_base_component_t *static_components[],
-					  const char *requested_components,
-                                          ocoms_list_t *found_components,
-                                          bool open_dso_components);
+                                                 const ocoms_mca_base_component_t *static_components[],
+                                                 const char *requested_components,
+                                                 ocoms_list_t *found_components,
+                                                 bool open_dso_components, ocoms_mca_base_open_flag_t flags);
 
 /**
  * Parse the requested component string and return an ocoms_argv of the requested
@@ -180,7 +180,8 @@ int ocoms_mca_base_component_parse_requested (const char *requested, bool *inclu
  * filter flags.
  */
 OCOMS_DECLSPEC int ocoms_mca_base_components_filter (const char *framework_name, ocoms_list_t *components, int output_id,
-					      const char *filter_names, uint32_t filter_flags);
+                                                     const char *filter_names, uint32_t filter_flags,
+                                                     ocoms_mca_base_open_flag_t flags);
 
 
 

--- a/ocoms/mca/base/mca_base_component_find.c
+++ b/ocoms/mca/base/mca_base_component_find.c
@@ -177,10 +177,10 @@ void ocoms_string_concat_delimited(char *dest, const char **input, int count, ch
  * available components.
  */
 int ocoms_mca_base_component_find(const char *directory, const char *type, 
-                            const ocoms_mca_base_component_t *static_components[], 
-                            const char *requested_components,
-                            ocoms_list_t *found_components,
-                            bool open_dso_components)
+                                  const ocoms_mca_base_component_t *static_components[],
+                                  const char *requested_components,
+                                  ocoms_list_t *found_components,
+                                  bool open_dso_components, ocoms_mca_base_open_flag_t flags)
 {
     char **requested_component_names = NULL;
     ocoms_mca_base_component_list_item_t *cli;
@@ -222,7 +222,7 @@ int ocoms_mca_base_component_find(const char *directory, const char *type,
                             type);
     }
 #endif
-    if (include_mode) {
+    if (include_mode && !(flags & MCA_BASE_FRAMEWORK_FLAG_NO_COMPONENT_FIND_CHECK)) {
         ret = component_find_check (type, requested_component_names, found_components);
     } else {
         ret = OCOMS_SUCCESS;
@@ -258,7 +258,8 @@ int ocoms_mca_base_component_find_finalize(void)
 }
 
 int ocoms_mca_base_components_filter (const char *framework_name, ocoms_list_t *components, int output_id,
-                                const char *filter_names, uint32_t filter_flags)
+                                      const char *filter_names, uint32_t filter_flags,
+                                      ocoms_mca_base_open_flag_t flags)
 {
     ocoms_mca_base_component_list_item_t *cli, *next;
     char **requested_component_names = NULL;
@@ -309,7 +310,7 @@ int ocoms_mca_base_components_filter (const char *framework_name, ocoms_list_t *
         }
     }
 
-    if (include_mode) {
+    if (include_mode && !(flags & MCA_BASE_FRAMEWORK_FLAG_NO_COMPONENT_FIND_CHECK)) {
         ret = component_find_check (framework_name, requested_component_names, components);
     } else {
         ret = OCOMS_SUCCESS;

--- a/ocoms/mca/base/mca_base_components_open.c
+++ b/ocoms/mca/base/mca_base_components_open.c
@@ -39,7 +39,7 @@
 /*
  * Local functions
  */
-static int open_components(ocoms_mca_base_framework_t *framework);
+static int open_components(ocoms_mca_base_framework_t *framework, ocoms_mca_base_open_flag_t flags);
 
 struct ocoms_mca_base_dummy_framework_list_item_t {
     ocoms_list_item_t super;
@@ -57,15 +57,15 @@ int ocoms_mca_base_framework_components_open (ocoms_mca_base_framework_t *framew
     if (flags & MCA_BASE_OPEN_FIND_COMPONENTS) {
         /* Find and load requested components */
         int ret = ocoms_mca_base_component_find(NULL, framework->framework_name,
-                                          framework->framework_static_components,
-                                          framework->framework_selection,
-                                          &framework->framework_components, true);
+                                                framework->framework_static_components,
+                                                framework->framework_selection,
+                                                &framework->framework_components, true, flags);
         if (OCOMS_SUCCESS != ret) {
             return ret;
         }
     }
     /* Open all registered components */
-    return open_components (framework);
+    return open_components (framework, flags);
 }
 
 int ocoms_mca_base_components_open (const char *type_name, int output_id,
@@ -123,7 +123,7 @@ int ocoms_mca_base_components_open (const char *type_name, int output_id,
  * components is in the requested_components_array, try to open it.
  * If it opens, add it to the components_available list.
  */
-static int open_components(ocoms_mca_base_framework_t *framework)
+static int open_components(ocoms_mca_base_framework_t *framework, ocoms_mca_base_open_flag_t flags)
 {
     ocoms_list_t *components = &framework->framework_components;
     uint32_t open_only_flags = MCA_BASE_METADATA_PARAM_NONE;
@@ -152,8 +152,8 @@ static int open_components(ocoms_mca_base_framework_t *framework)
     /* If ocoms_mca_base_framework_register_components was called with the MCA_BASE_COMPONENTS_ALL flag 
        we need to trim down and close any extra components we do not want open */
     ret = ocoms_mca_base_components_filter (framework->framework_name, &framework->framework_components,
-                                      framework->framework_output, framework->framework_selection,
-                                      open_only_flags);
+                                            framework->framework_output, framework->framework_selection,
+                                            open_only_flags, flags);
     if (OCOMS_SUCCESS != ret) {
         return ret;
     }

--- a/ocoms/mca/base/mca_base_components_register.c
+++ b/ocoms/mca/base/mca_base_components_register.c
@@ -57,9 +57,9 @@ int ocoms_mca_base_framework_components_register (ocoms_mca_base_framework_t *fr
 
     /* Find and load requested components */
     ret = ocoms_mca_base_component_find(NULL, framework->framework_name,
-                                  framework->framework_static_components,
-                                  ignore_requested ? NULL : framework->framework_selection,
-                                  &components_found, open_dso_components);
+                                        framework->framework_static_components,
+                                        ignore_requested ? NULL : framework->framework_selection,
+                                        &components_found, open_dso_components, flags);
 
     if (OCOMS_SUCCESS != ret) {
         return ret;

--- a/ocoms/mca/base/mca_base_framework.h
+++ b/ocoms/mca/base/mca_base_framework.h
@@ -112,7 +112,7 @@ typedef enum {
     MCA_BASE_FRAMEWORK_FLAG_NOREGISTER = 1,
     /** Internal. Don't set outside ocoms_mca_base_framework.h */
     MCA_BASE_FRAMEWORK_FLAG_REGISTERED = 2,
-
+    MCA_BASE_FRAMEWORK_FLAG_NO_COMPONENT_FIND_CHECK = 3,
     /**
      * The upper 16 bits are reserved for project specific flags.
      */


### PR DESCRIPTION
    This option (flag MCA_BASE_FRAMEWORK_FLAG_NO_COMPONENT_FIND_CHECK)
    is usefull when the calling runtime does not want to treat the
    absence of a component as error.

    (Used in hcoll bcol component open flow in order to skip absent components w/o failing overall hcoll init)