### PR TITLE
Optionally search for -lcuda in cuda/stubs

### DIFF
--- a/config/ocoms_configure_options.m4
+++ b/config/ocoms_configure_options.m4
@@ -596,7 +596,7 @@ AS_IF([test "x$with_cuda" = "xno"],
             CUDA_LDFLAGS="-L$ucx_check_cuda_libdir"])
 
      CPPFLAGS+=" $CUDA_CPPFLAGS"
-     LDFLAGS+=" $CUDA_LDFLAGS"
+     LDFLAGS+=" $CUDA_LDFLAGS -L$ucx_check_cuda_libdir/stubs"
 
      # Check cuda header files
               AC_CHECK_HEADERS([cuda.h cuda_runtime.h],


### PR DESCRIPTION
    When compiling -lcuda can be available only in the
    CUDA_HOME/lib64/stubs location